### PR TITLE
Updated setup.py to work in Python3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
+import io
 
-
-with open('README.md') as f:
+with io.open('README.md', encoding='utf-8') as f:
     readme = f.read()
-with open('LICENSE') as f:
+with io.open('LICENSE', encoding='utf-8') as f:
     license = f.read()
 
 


### PR DESCRIPTION
I've updated the setup.py to work in python3.5.  Current version fails on Python3.5 because of UnicodeError.

Tested in Python3.5, Python3.4 & python2.7.
